### PR TITLE
add links to sign up, login, logout forms to the main layout nav bar

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,6 +22,14 @@ html lang="en"
           = "Task Manager"
         .mdl-layout-spacer
         nav.mdl-navigation
+          = link_to "Board", board_path, class: 'mdl-navigation__link'
+          - if current_user
+            - if current_user.is_a? Admin
+              = link_to "Admin page", admin_users_url, class: 'mdl-navigation__link'
+            = link_to "Log out", session_path, method: "delete", confirm: "confirm?", class: 'mdl-navigation__link'
+          - else
+            = link_to "Sign in", new_session_path, class: 'mdl-navigation__link'
+            = link_to "Sign up", new_developers_path, class: 'mdl-navigation__link'
     main#main.mdl-layout__content
       .page-content
         = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,7 +29,7 @@ html lang="en"
             = link_to "Log out", session_path, method: "delete", confirm: "confirm?", class: 'mdl-navigation__link'
           - else
             = link_to "Sign in", new_session_path, class: 'mdl-navigation__link'
-            = link_to "Sign up", new_developers_path, class: 'mdl-navigation__link'
+            = link_to "Sign up", new_developer_path, class: 'mdl-navigation__link'
     main#main.mdl-layout__content
       .page-content
         = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   scope module: :web do
     resource :board, only: :show
     resource :session, only: [:new, :create, :destroy]
-    resource :developers, only: [:new, :create]
+    resources :developers, only: [:new, :create]
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Смущает один момент. В [задании](https://learn.dualboot.ru/courses/5/lessons/76/practices/1146) для ссылки на регистрацию предлагается указать путь `new_developer_path`. Однако на [предыдущем уроке](https://learn.dualboot.ru/courses/5/lessons/76/practices/1145) мы писали роуты используя `developers`.

Как все-таки правильно делать? Думается, что в роутах должно быть `developer`...